### PR TITLE
Disable variable, month, year selectors while data loading

### DIFF
--- a/src/HOCs/withLifeCycleLogging.js
+++ b/src/HOCs/withLifeCycleLogging.js
@@ -59,7 +59,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import isEqual from 'lodash/isEqual';
+// import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import union from 'lodash/union';
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import logger from '../../logger';
 import Header from '../Header';
 import Tool from '../Tool'
@@ -10,7 +11,6 @@ logger.configure({active: true});
 
 class App extends Component {
     render() {
-        logger.log(this);
         return (
             <div className="App">
                 <Header/>
@@ -20,4 +20,4 @@ class App extends Component {
     }
 }
 
-export default App;
+export default withLifeCycleLogging.hoc()(App);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import logger from '../../logger';
 import Header from '../Header';
 import Tool from '../Tool'
@@ -20,4 +19,4 @@ class App extends Component {
     }
 }
 
-export default withLifeCycleLogging.hoc()(App);
+export default App;

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,7 +7,7 @@ import Tool from '../Tool'
 
 import './App.css';
 
-logger.configure({active: true});
+logger.configure({active: !!process.env.LOGGING});
 
 class App extends Component {
     render() {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,7 +7,7 @@ import Tool from '../Tool'
 
 import './App.css';
 
-logger.configure({active: !!process.env.LOGGING});
+logger.configure({active: true});
 
 class App extends Component {
     render() {

--- a/src/components/BCMap/BCMap.js
+++ b/src/components/BCMap/BCMap.js
@@ -15,6 +15,9 @@ import L from 'leaflet';
 import 'proj4';
 import 'proj4leaflet';
 import 'leaflet/dist/leaflet.css';
+
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
+
 import './BCMap.css';
 
 class BCMap extends Component {
@@ -86,4 +89,4 @@ BCMap.initial = {
     zoom: 2,
 };
 
-export default BCMap;
+export default withLifeCycleLogging.hoc()(BCMap);

--- a/src/components/BCMap/BCMap.js
+++ b/src/components/BCMap/BCMap.js
@@ -5,7 +5,7 @@
 //
 // For prop definitions, see comments in BCMap.propTypes.
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -20,40 +20,37 @@ import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 
 import './BCMap.css';
 
-class BCMap extends Component {
-    constructor(props) {
-        super(props);
-
-        const maxRes = 7812.5;
-        this.resolutions = [];
-        for (let i = 0; i < 12; i += 1) {
-            this.resolutions.push(maxRes / Math.pow(2, i));
-        }
-        this.crs = new L.Proj.CRS(
-            'EPSG:3005',
-            '+proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
-            {
-                resolutions: this.resolutions,
-                // If we don't set the origin correctly, then the projection transforms BC Albers coordinates to lat-lng
-                // coordinates incorrectly. You have to know the magic origin value.
-                //
-                // It is also probably important to know that the bc_osm tile set is a TMS tile set, which has axes
-                // transposed with respect to Leaflet axes. The proj4leaflet documentation incorrectly states that
-                // there is a CRS constructor `L.Proj.CRS.TMS` for TMS tilesets. It is absent in the recent version
-                // (1.0.2) we are using. It exists in proj4leaflet ver 0.7.1 (in use in CE), and shows that the
-                // correct value for the origin option is `[bounds[0], bounds[3]]`, where `bounds` is the 3rd argument
-                // of the TMS constructor. These values are defined for us in Climate Explorer's version of this map.
-                // W00t.
-                origin: [-1000000, 3000000],
-            }
-        );
+// Set up BC Albers projection
+const maxRes = 7812.5;
+let resolutions = [];
+for (let i = 0; i < 12; i += 1) {
+    resolutions.push(maxRes / Math.pow(2, i));
+}
+const crs = new L.Proj.CRS(
+    'EPSG:3005',
+    '+proj=aea +lat_1=50 +lat_2=58.5 +lat_0=45 +lon_0=-126 +x_0=1000000 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs',
+    {
+        resolutions,
+        // If we don't set the origin correctly, then the projection transforms BC Albers coordinates to lat-lng
+        // coordinates incorrectly. You have to know the magic origin value.
+        //
+        // It is also probably important to know that the bc_osm tile set is a TMS tile set, which has axes
+        // transposed with respect to Leaflet axes. The proj4leaflet documentation incorrectly states that
+        // there is a CRS constructor `L.Proj.CRS.TMS` for TMS tilesets. It is absent in the recent version
+        // (1.0.2) we are using. It exists in proj4leaflet ver 0.7.1 (in use in CE), and shows that the
+        // correct value for the origin option is `[bounds[0], bounds[3]]`, where `bounds` is the 3rd argument
+        // of the TMS constructor. These values are defined for us in Climate Explorer's version of this map.
+        // W00t.
+        origin: [-1000000, 3000000],
     }
+);
 
+class BCMap extends PureComponent {
     render() {
         const center = _.pick(BCMap.initial, 'lat', 'lng');
         return (
             <Map
-                crs={this.crs}
+                crs={crs}
                 center={center}
                 zoom={BCMap.initial.zoom}
                 minZoom={0}   // ?

--- a/src/components/BCMap/BCMap.js
+++ b/src/components/BCMap/BCMap.js
@@ -16,7 +16,6 @@ import 'proj4';
 import 'proj4leaflet';
 import 'leaflet/dist/leaflet.css';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 
 import './BCMap.css';
 
@@ -86,4 +85,4 @@ BCMap.initial = {
     zoom: 2,
 };
 
-export default withLifeCycleLogging.hoc()(BCMap);
+export default BCMap;

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -12,6 +12,7 @@ import { LayerGroup, LayersControl, CircleMarker } from 'react-leaflet';
 
 import _ from 'lodash';
 
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import BCMap from '../BCMap';
 import MessageControl from '../MessageControl';
@@ -137,4 +138,4 @@ DataMap.defaultProps = {
     message: null,
 };
 
-export default DataMap;
+export default withLifeCycleLogging.hoc()(DataMap);

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -5,7 +5,7 @@
 //
 // For prop definitions, see comments in BCMap.propTypes.
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import { LayerGroup, LayersControl, CircleMarker } from 'react-leaflet';
@@ -70,7 +70,7 @@ function StationDataMarkers({variable, stations}) {
     );
 }
 
-class DataMap extends Component {
+class DataMap extends PureComponent {
     stationsForDataset() {
         // Return a set of stations determined by `this.props.dataset`.
         // For `baseline` and `monthly`, return the respective station sets.

--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -12,7 +12,6 @@ import { LayerGroup, LayersControl, CircleMarker } from 'react-leaflet';
 
 import _ from 'lodash';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import BCMap from '../BCMap';
 import MessageControl from '../MessageControl';
@@ -138,4 +137,4 @@ DataMap.defaultProps = {
     message: null,
 };
 
-export default withLifeCycleLogging.hoc()(DataMap);
+export default DataMap;

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -73,6 +73,12 @@ DataViewer.propTypes = {
     onDataDidCatch: PropTypes.func,
 };
 
+DataViewer.defaultProps ={
+    onDataWillLoad: () => {},
+    onDataDidLoad: () => {},
+    onDataDidCatch: () => {},
+};
+
 DataViewer.noDataState = {
     baseline: [],
     monthly: [],

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -5,10 +5,16 @@ import logger from '../../logger';
 import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick, bindFunctions } from '../utils';
 import TestDataLoader from '../TestDataLoader';
-// import FakeDataLoader from '../FakeDataLoader';
+import FakeDataLoader from '../FakeDataLoader';
 import RealDataLoader from '../RealDataLoader';
 import DataMap from '../DataMap';
 import './DataViewer.css';
+
+const DataLoader = {
+    'test': TestDataLoader,
+    'fake': FakeDataLoader,
+    'real': RealDataLoader,
+}[process.env.DATA_LOADER || 'real'];
 
 class DataViewer extends PureComponent {
     constructor(props) {
@@ -46,7 +52,7 @@ class DataViewer extends PureComponent {
     render() {
         return (
             <div>
-                <TestDataLoader
+                <DataLoader
                     {...pick(this.props, 'variable year month')}
                     onDataWillLoad={this.handleDataWillLoad}
                     onDataDidLoad={this.handleDataDidLoad}
@@ -54,10 +60,8 @@ class DataViewer extends PureComponent {
                     errorTest
                 />
                 <DataMap
-                    {...{
-                        ...pick(this.props, 'dataset variable'),
-                        ...pick(this.state, 'baseline monthly message'),
-                    }}
+                    {...pick(this.props, 'dataset variable')}
+                    {...pick(this.state, 'baseline monthly message')}
                 />
             </div>
         );

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import logger from '../../logger';
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick, bindFunctions } from '../utils';
 import TestDataLoader from '../TestDataLoader';
 // import FakeDataLoader from '../FakeDataLoader';
@@ -84,4 +85,4 @@ DataViewer.noDataState = {
     monthly: [],
 };
 
-export default DataViewer;
+export default withLifeCycleLogging.hoc()(DataViewer);

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import logger from '../../logger';
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick, bindFunctions } from '../utils';
 import TestDataLoader from '../TestDataLoader';
 import FakeDataLoader from '../FakeDataLoader';
@@ -89,4 +88,4 @@ DataViewer.noDataState = {
     monthly: [],
 };
 
-export default withLifeCycleLogging.hoc()(DataViewer);
+export default DataViewer;

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -56,7 +56,7 @@ class DataViewer extends PureComponent {
                     onDataWillLoad={this.handleDataWillLoad}
                     onDataDidLoad={this.handleDataDidLoad}
                     onDidCatch={this.handleDidCatch}
-                    errorTest
+                    // errorTest
                 />
                 <DataMap
                     {...pick(this.props, 'dataset variable')}

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -22,6 +22,7 @@ class DataViewer extends Component {
             ...DataViewer.noDataState,
             message: 'Data loading ...',
         });
+        this.props.onDataWillLoad();
     }
 
     handleDataDidLoad(data) {
@@ -30,6 +31,7 @@ class DataViewer extends Component {
             ...data,
             message: null,
         });
+        this.props.onDataDidLoad(data);
     }
 
     handleDidCatch(error) {
@@ -37,6 +39,7 @@ class DataViewer extends Component {
         this.setState({
             message: 'Error loading data: ' + error.message,
         });
+        this.props.onDataDidCatch(error);
     }
 
     render() {
@@ -65,6 +68,9 @@ DataViewer.propTypes = {
     variable: PropTypes.string.isRequired,
     year: PropTypes.number.isRequired,
     month: PropTypes.number.isRequired,
+    onDataWillLoad: PropTypes.func,
+    onDataDidLoad: PropTypes.func,
+    onDataDidCatch: PropTypes.func,
 };
 
 DataViewer.noDataState = {

--- a/src/components/DataViewer/DataViewer.js
+++ b/src/components/DataViewer/DataViewer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import logger from '../../logger';
@@ -10,7 +10,7 @@ import RealDataLoader from '../RealDataLoader';
 import DataMap from '../DataMap';
 import './DataViewer.css';
 
-class DataViewer extends Component {
+class DataViewer extends PureComponent {
     constructor(props) {
         super(props);
         this.state = DataViewer.noDataState;

--- a/src/components/DatasetSelector/DatasetSelector.js
+++ b/src/components/DatasetSelector/DatasetSelector.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
@@ -7,13 +7,14 @@ import RadioButtonSelector from '../RadioButtonSelector';
 import './DatasetSelector.css';
 
 
-class DatasetSelector extends Component {
+const datasets = [
+    { value: 'anomaly', label: 'Anomaly', },
+    { value: 'monthly', label: 'Monthly', },
+    { value: 'baseline', label: 'Baseline', },
+];
+
+class DatasetSelector extends PureComponent {
     render() {
-        const datasets = [
-            { value: 'anomaly', label: 'Anomaly', },
-            { value: 'monthly', label: 'Monthly', },
-            { value: 'baseline', label: 'Baseline', },
-        ];
         return (
             <RadioButtonSelector
                 className={this.props.className}

--- a/src/components/DatasetSelector/DatasetSelector.js
+++ b/src/components/DatasetSelector/DatasetSelector.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import RadioButtonSelector from '../RadioButtonSelector';
 import './DatasetSelector.css';
@@ -28,4 +30,4 @@ DatasetSelector.propTypes = {
     onChange: PropTypes.func.isRequired,
 };
 
-export default DatasetSelector;
+export default withLifeCycleLogging.hoc()(DatasetSelector);

--- a/src/components/DatasetSelector/DatasetSelector.js
+++ b/src/components/DatasetSelector/DatasetSelector.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import RadioButtonSelector from '../RadioButtonSelector';
 import './DatasetSelector.css';
@@ -31,4 +30,4 @@ DatasetSelector.propTypes = {
     onChange: PropTypes.func.isRequired,
 };
 
-export default withLifeCycleLogging.hoc()(DatasetSelector);
+export default DatasetSelector;

--- a/src/components/FakeDataLoader/FakeDataLoader.js
+++ b/src/components/FakeDataLoader/FakeDataLoader.js
@@ -5,6 +5,7 @@ import { Row, Col } from 'react-bootstrap';
 import _ from 'lodash';
 
 import logger from '../../logger';
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import './FakeDataLoader.css';
 
 import baseline_precip_1 from './dummy-data/baseline-precip-1.json';
@@ -130,4 +131,4 @@ FakeDataLoader.propTypes = {
     onDidCatch: PropTypes.func.isRequired,
 };
 
-export default FakeDataLoader;
+export default withLifeCycleLogging.hoc()(FakeDataLoader);

--- a/src/components/FakeDataLoader/FakeDataLoader.js
+++ b/src/components/FakeDataLoader/FakeDataLoader.js
@@ -5,7 +5,6 @@ import { Row, Col } from 'react-bootstrap';
 import _ from 'lodash';
 
 import logger from '../../logger';
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import './FakeDataLoader.css';
 
 import baseline_precip_1 from './dummy-data/baseline-precip-1.json';
@@ -131,4 +130,4 @@ FakeDataLoader.propTypes = {
     onDidCatch: PropTypes.func.isRequired,
 };
 
-export default withLifeCycleLogging.hoc()(FakeDataLoader);
+export default FakeDataLoader;

--- a/src/components/FakeDataLoader/FakeDataLoader.js
+++ b/src/components/FakeDataLoader/FakeDataLoader.js
@@ -26,7 +26,7 @@ let index = 0;
 
 // Placeholder for real async data retrieval
 function getFakeData(delay, failProb) {
-    console.log(this, 'getFakeData', {time:  (new Date()).getSeconds(), delay, failProb});
+    logger.log(this, {delay, failProb});
     return new Promise((resolve, reject) => {
         setTimeout(function() {
             if (Math.random() >= failProb) {

--- a/src/components/IncrementDecrement/IncrementDecrement.js
+++ b/src/components/IncrementDecrement/IncrementDecrement.js
@@ -6,23 +6,32 @@
 // Increment/decrement amount can be a single fixed number, or can be selected by dropdown control
 // from an array of numbers, according to the type of property `by`.
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroup, Button, Glyphicon, DropdownButton, MenuItem } from 'react-bootstrap';
 
 import classNames from 'classnames';
 
 import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
-import { pick } from '../utils';
+import { bindFunctions, pick } from '../utils';
 
 import './IncrementDecrement.css';
 
-class IncrementDecrement extends Component {
+class IncrementDecrement extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
             by: Array.isArray(this.props.by) ? this.props.by[0] : this.props.by,
         };
+        bindFunctions(this, 'onDecrement onIncrement')
+    }
+
+    onDecrement() {
+        this.props.onIncrement(-this.state.by)
+    }
+
+    onIncrement() {
+        this.props.onIncrement(this.state.by)
     }
 
     render() {
@@ -48,7 +57,7 @@ class IncrementDecrement extends Component {
                 <Button
                     bsSize={this.props.bsSize}
                     disabled={this.props.disabled}
-                    onClick={() => this.props.onIncrement(-this.state.by)}
+                    onClick={this.onDecrement}
                 >
                     <Glyphicon glyph={'minus'}/>
                 </Button>
@@ -56,7 +65,7 @@ class IncrementDecrement extends Component {
                 <Button
                     bsSize={this.props.bsSize}
                     disabled={this.props.disabled}
-                    onClick={() => this.props.onIncrement(this.state.by)}
+                    onClick={this.onIncrement}
                 >
                     <Glyphicon glyph={'plus'}/>
                 </Button>

--- a/src/components/IncrementDecrement/IncrementDecrement.js
+++ b/src/components/IncrementDecrement/IncrementDecrement.js
@@ -65,7 +65,7 @@ class IncrementDecrement extends Component {
 }
 
 IncrementDecrement.propTypes = {
-    disabled: PropTypes.boolean,
+    disabled: PropTypes.bool,
     // Is control disabled
     by: PropTypes.oneOfType([
         PropTypes.number,

--- a/src/components/IncrementDecrement/IncrementDecrement.js
+++ b/src/components/IncrementDecrement/IncrementDecrement.js
@@ -12,7 +12,6 @@ import { ButtonGroup, Button, Glyphicon, DropdownButton, MenuItem } from 'react-
 
 import classNames from 'classnames';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 
 import './IncrementDecrement.css';
@@ -94,4 +93,4 @@ IncrementDecrement.defaultProps = {
     by: 1,
 };
 
-export default withLifeCycleLogging.hoc()(IncrementDecrement);
+export default IncrementDecrement;

--- a/src/components/IncrementDecrement/IncrementDecrement.js
+++ b/src/components/IncrementDecrement/IncrementDecrement.js
@@ -12,6 +12,7 @@ import { ButtonGroup, Button, Glyphicon, DropdownButton, MenuItem } from 'react-
 
 import classNames from 'classnames';
 
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 
 import './IncrementDecrement.css';
@@ -84,4 +85,4 @@ IncrementDecrement.defaultProps = {
     by: 1,
 };
 
-export default IncrementDecrement;
+export default withLifeCycleLogging.hoc()(IncrementDecrement);

--- a/src/components/IncrementDecrement/IncrementDecrement.js
+++ b/src/components/IncrementDecrement/IncrementDecrement.js
@@ -41,12 +41,22 @@ class IncrementDecrement extends Component {
         }
 
         return (
-            <ButtonGroup className={classNames('IncrementDecrement', this.props.className)}>
-                <Button bsSize={this.props.bsSize} onClick={() => this.props.onIncrement(-this.state.by)}>
+            <ButtonGroup
+                className={classNames('IncrementDecrement', this.props.className)}
+            >
+                <Button
+                    bsSize={this.props.bsSize}
+                    disabled={this.props.disabled}
+                    onClick={() => this.props.onIncrement(-this.state.by)}
+                >
                     <Glyphicon glyph={'minus'}/>
                 </Button>
                 {selector}
-                <Button bsSize={this.props.bsSize} onClick={() => this.props.onIncrement(this.state.by)}>
+                <Button
+                    bsSize={this.props.bsSize}
+                    disabled={this.props.disabled}
+                    onClick={() => this.props.onIncrement(this.state.by)}
+                >
                     <Glyphicon glyph={'plus'}/>
                 </Button>
             </ButtonGroup>
@@ -55,6 +65,8 @@ class IncrementDecrement extends Component {
 }
 
 IncrementDecrement.propTypes = {
+    disabled: PropTypes.boolean,
+    // Is control disabled
     by: PropTypes.oneOfType([
         PropTypes.number,
         PropTypes.arrayOf(PropTypes.number)
@@ -68,6 +80,7 @@ IncrementDecrement.propTypes = {
 };
 
 IncrementDecrement.defaultProps = {
+    disabled: false,
     by: 1,
 };
 

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
-import logger from '../../logger';
 import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -1,6 +1,6 @@
 // TODO: YearSelector and MonthSelector are nearly identical. Use a HOC for them both.
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
@@ -14,7 +14,7 @@ import './MonthSelector.css';
 const monthNames = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
 const formatLabel = value => monthNames[value-1];
 
-class MonthSelector extends Component {
+class MonthSelector extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import InputRange from 'react-input-range';
 
 import logger from '../../logger';
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 
 import './MonthSelector.css';
@@ -27,14 +28,12 @@ class MonthSelector extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        logger.log(this, nextProps);
         if (nextProps.value !== this.state.value) {
             this.setState({value: nextProps.value});
         }
     }
 
     render() {
-        logger.log(this, this.props);
         return (
             <InputRange
                 {...pick(this.props, 'className disabled')}
@@ -69,4 +68,4 @@ MonthSelector.defaultProps = {
 };
 
 
-export default MonthSelector;
+export default withLifeCycleLogging.hoc()(MonthSelector);

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 
 import './MonthSelector.css';
@@ -67,4 +66,4 @@ MonthSelector.defaultProps = {
 };
 
 
-export default withLifeCycleLogging.hoc()(MonthSelector);
+export default MonthSelector;

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
-import { bindFunctions } from '../utils';
+import { bindFunctions, pick } from '../utils';
 
 import './MonthSelector.css';
 
@@ -34,7 +34,7 @@ class MonthSelector extends Component {
     render() {
         return (
             <InputRange
-                className={this.props.className}
+                {...pick(this.props, 'className disabled')}
                 minValue={this.props.start}
                 maxValue={this.props.end}
                 formatLabel={formatLabel}
@@ -47,17 +47,20 @@ class MonthSelector extends Component {
 }
 
 MonthSelector.propTypes = {
+    disabled: PropTypes.boolean,
+    // Is control disabled
     start: PropTypes.number,
     // Start month
     end: PropTypes.number,
     // End month
     value: PropTypes.number,
-    // Current value (year)
+    // Current value (month)
     onChange: PropTypes.func.isRequired,
     // Called with value when dragging complete (no intermediate values)
 };
 
 MonthSelector.defaultProps = {
+    disabled: false,
     start: 1,
     end: 12,
 };

--- a/src/components/MonthSelector/MonthSelector.js
+++ b/src/components/MonthSelector/MonthSelector.js
@@ -47,7 +47,7 @@ class MonthSelector extends Component {
 }
 
 MonthSelector.propTypes = {
-    disabled: PropTypes.boolean,
+    disabled: PropTypes.bool,
     // Is control disabled
     start: PropTypes.number,
     // Start month

--- a/src/components/MonthSelector/__tests__/smoke.js
+++ b/src/components/MonthSelector/__tests__/smoke.js
@@ -6,6 +6,7 @@ it('renders without crashing', () => {
     const div = document.createElement('div');
     ReactDOM.render(
         <MonthSelector
+            value={1}
             onChange={() => {}}
         />,
         div

--- a/src/components/RadioButtonSelector/RadioButtonSelector.js
+++ b/src/components/RadioButtonSelector/RadioButtonSelector.js
@@ -16,7 +16,6 @@ import PropTypes from 'prop-types';
 import { ToggleButtonGroup, ToggleButton } from 'react-bootstrap';
 import classNames from 'classnames';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import './RadioButtonSelector.css';
 
@@ -64,4 +63,4 @@ RadioButtonSelector.defaultProps = {
     disabled: false,
 };
 
-export default withLifeCycleLogging.hoc({active: false})(RadioButtonSelector);
+export default RadioButtonSelector;

--- a/src/components/RadioButtonSelector/RadioButtonSelector.js
+++ b/src/components/RadioButtonSelector/RadioButtonSelector.js
@@ -41,7 +41,7 @@ class RadioButtonSelector extends Component {
 }
 
 RadioButtonSelector.propTypes = {
-    disabled: PropTypes.boolean,
+    disabled: PropTypes.bool,
     // Is control disabled
     name: PropTypes.string.isRequired,
     // An HTML <input> name for each child button

--- a/src/components/RadioButtonSelector/RadioButtonSelector.js
+++ b/src/components/RadioButtonSelector/RadioButtonSelector.js
@@ -11,6 +11,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ToggleButtonGroup, ToggleButton } from 'react-bootstrap';
 import classNames from 'classnames';
+
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import './RadioButtonSelector.css';
 
@@ -58,4 +60,4 @@ RadioButtonSelector.defaultProps = {
     disabled: false,
 };
 
-export default RadioButtonSelector;
+export default withLifeCycleLogging.hoc({active: false})(RadioButtonSelector);

--- a/src/components/RadioButtonSelector/RadioButtonSelector.js
+++ b/src/components/RadioButtonSelector/RadioButtonSelector.js
@@ -19,7 +19,9 @@ class RadioButtonSelector extends Component {
         const toggleButtons = this.props.options.map((option) => (
             <ToggleButton
                 className={classNames('RadioButtonSelector-button', this.props.className)}
-                key={option.value} value={option.value}
+                disabled={this.props.disabled}
+                key={option.value}
+                value={option.value}
             >
                 {option.label}
             </ToggleButton>
@@ -39,6 +41,8 @@ class RadioButtonSelector extends Component {
 }
 
 RadioButtonSelector.propTypes = {
+    disabled: PropTypes.boolean,
+    // Is control disabled
     name: PropTypes.string.isRequired,
     // An HTML <input> name for each child button
     options: PropTypes.array.isRequired,
@@ -51,7 +55,7 @@ RadioButtonSelector.propTypes = {
 };
 
 RadioButtonSelector.defaultProps = {
-    height: 10,
+    disabled: false,
 };
 
 export default RadioButtonSelector;

--- a/src/components/RadioButtonSelector/RadioButtonSelector.js
+++ b/src/components/RadioButtonSelector/RadioButtonSelector.js
@@ -1,13 +1,17 @@
 // RadioButtonSelector - a component that provides a selector as a vertical scrollable list of (radio) buttons.
 //
 // For prop definitions, see RadioButtonSelector.propTypes
+//
+// CAUTION: This is a PureComponent, and therefore props.options must be an immutable value, or
+// else PureComponent's shallow comparison will not pick up changes to it and not update correctly.
+// In present use, this is the case.
 
 // TODO: Add props.style and pass thru to ToggleButtonGroup
 // TODO: Add prop for option item height?
 // TODO: (as called for) Make vertical a prop
 // TODO: Use inline styles only
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { ToggleButtonGroup, ToggleButton } from 'react-bootstrap';
 import classNames from 'classnames';
@@ -16,7 +20,7 @@ import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import './RadioButtonSelector.css';
 
-class RadioButtonSelector extends Component {
+class RadioButtonSelector extends PureComponent {
     render() {
         const toggleButtons = this.props.options.map((option) => (
             <ToggleButton

--- a/src/components/RealDataLoader/RealDataLoader.js
+++ b/src/components/RealDataLoader/RealDataLoader.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Row } from 'react-bootstrap';
 
@@ -11,7 +11,7 @@ import { getBaselineData, getMonthlyData } from '../../data-services/weather-ano
 
 import './RealDataLoader.css';
 
-class RealDataLoader extends Component {
+class RealDataLoader extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/RealDataLoader/RealDataLoader.js
+++ b/src/components/RealDataLoader/RealDataLoader.js
@@ -38,7 +38,7 @@ class RealDataLoader extends PureComponent {
         this.setState({loading: true});
         this.props.onDataWillLoad();
 
-        // This may be inefficient when only month changes
+        // TODO: Don't reload baseline data when month doesn't change
         const baselineP = getBaselineData(variable, this.props.errorTest && month === 12 ? 13: month);
         const monthlyP = getMonthlyData(variable, year, month);
         Promise.all([baselineP, monthlyP]).then(this.dataDidLoad).catch(this.dataLoadError);

--- a/src/components/RealDataLoader/RealDataLoader.js
+++ b/src/components/RealDataLoader/RealDataLoader.js
@@ -5,6 +5,7 @@ import { Row } from 'react-bootstrap';
 import _ from 'lodash';
 
 import logger from '../../logger';
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions } from '../utils';
 import { getBaselineData, getMonthlyData } from '../../data-services/weather-anomaly-data-service';
 
@@ -89,4 +90,4 @@ RealDataLoader.defaultProps = {
     errorTest: false,
 };
 
-export default RealDataLoader;
+export default withLifeCycleLogging.hoc()(RealDataLoader);

--- a/src/components/RealDataLoader/RealDataLoader.js
+++ b/src/components/RealDataLoader/RealDataLoader.js
@@ -5,7 +5,6 @@ import { Row } from 'react-bootstrap';
 import _ from 'lodash';
 
 import logger from '../../logger';
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions } from '../utils';
 import { getBaselineData, getMonthlyData } from '../../data-services/weather-anomaly-data-service';
 
@@ -90,4 +89,4 @@ RealDataLoader.defaultProps = {
     errorTest: false,
 };
 
-export default withLifeCycleLogging.hoc()(RealDataLoader);
+export default RealDataLoader;

--- a/src/components/StationPopup/StationPopup.js
+++ b/src/components/StationPopup/StationPopup.js
@@ -4,7 +4,7 @@ import { Popup } from 'react-leaflet'
 import './StationPopup.css';
 
 const unitsForVariable = {
-    'precip': 'mm/day',
+    'precip': 'mm/mon',
     'tmin': 'C',
     'tmax': 'C',
 };

--- a/src/components/StationPopup/StationPopup.js
+++ b/src/components/StationPopup/StationPopup.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Popup } from 'react-leaflet'
 import './StationPopup.css';
@@ -14,7 +14,7 @@ const decimalPlacesForVariable = {
     'tmax': 2,
 };
 
-class StationPopup extends Component {
+class StationPopup extends PureComponent {
     render() {
         const units = unitsForVariable[this.props.variable];
         const decimalPlaces = decimalPlacesForVariable[this.props.variable];

--- a/src/components/TestDataLoader/TestDataLoader.js
+++ b/src/components/TestDataLoader/TestDataLoader.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import DataLoaderMode from '../DataLoaderMode';
 import FakeDataLoader from "../FakeDataLoader/FakeDataLoader";
@@ -45,4 +46,4 @@ TestDataLoader.propTypes = {
     onDidCatch: PropTypes.func.isRequired,
 };
 
-export default TestDataLoader;
+export default withLifeCycleLogging.hoc()(TestDataLoader);

--- a/src/components/TestDataLoader/TestDataLoader.js
+++ b/src/components/TestDataLoader/TestDataLoader.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import DataLoaderMode from '../DataLoaderMode';
 import FakeDataLoader from "../FakeDataLoader/FakeDataLoader";
@@ -46,4 +45,4 @@ TestDataLoader.propTypes = {
     onDidCatch: PropTypes.func.isRequired,
 };
 
-export default withLifeCycleLogging.hoc()(TestDataLoader);
+export default TestDataLoader;

--- a/src/components/Tool/Tool.css
+++ b/src/components/Tool/Tool.css
@@ -29,7 +29,7 @@
 }
 
 .Tool .selectors .input-range__track--active {
-    background: #777777;
+    /*background: #777777;*/
 }
 
 .Tool .selectors .input-range__track {
@@ -37,8 +37,8 @@
 }
 
 .Tool .selectors .input-range__slider {
-    background: #777777;
-    border-color: #777777;
+    /*background: #777777;*/
+    /*border-color: #777777;*/
     height: 1em;
     width: 1em;
     margin-left: -0.5em;

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import { Grid, Row, Col } from 'react-bootstrap';
 
 import logger from '../../logger';
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 import DatasetSelector from '../DatasetSelector'
 import VariableSelector from '../VariableSelector'
@@ -142,4 +141,4 @@ class Tool extends PureComponent {
     }
 }
 
-export default withLifeCycleLogging.hoc()(Tool);
+export default Tool;

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Grid, Row, Col } from 'react-bootstrap';
 
 import logger from '../../logger';
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 import DatasetSelector from '../DatasetSelector'
 import VariableSelector from '../VariableSelector'
@@ -23,13 +24,23 @@ class Tool extends Component {
             month: 6,
             dataLoading: false,
         };
-        bindFunctions(this, 'handleIncrementYear handleIncrementMonth handleDataIsLoading handleDataIsNotLoading');
+        bindFunctions(this, 'handleChangeVariable handleChangeDataset handleChangeMonth handleChangeYear handleIncrementYear handleIncrementMonth handleDataIsLoading handleDataIsNotLoading');
     }
 
-    makeHandleChange(item) {
-        return (function(value) {
-            this.setState({[item]: value});
-        }).bind(this);
+    handleChangeVariable(variable) {
+        this.setState({variable});
+    }
+
+    handleChangeDataset(dataset) {
+        this.setState({dataset});
+    }
+
+    handleChangeMonth(month) {
+        this.setState({month});
+    }
+
+    handleChangeYear(year) {
+        this.setState({year});
     }
 
     handleIncrementYear(by) {
@@ -54,7 +65,6 @@ class Tool extends Component {
     }
 
     render() {
-        logger.log(this);
         const isBaselineDataset = this.state.dataset === 'baseline';
         return (
             <Grid fluid className="Tool">
@@ -67,13 +77,13 @@ class Tool extends Component {
                                 <VariableSelector
                                     disabled={this.state.dataLoading}
                                     value={this.state.variable}
-                                    onChange={this.makeHandleChange('variable')}
+                                    onChange={this.handleChangeVariable}
                                 />
                             </Col>
                             <Col lg={4}>
                                 <DatasetSelector
                                     value={this.state.dataset}
-                                    onChange={this.makeHandleChange('dataset')}
+                                    onChange={this.handleChangeDataset}
                                 />
                             </Col>
                             <Col lg={2}/>
@@ -84,7 +94,7 @@ class Tool extends Component {
                                 <MonthSelector
                                     disabled={this.state.dataLoading}
                                     value={this.state.month}
-                                    onChange={this.makeHandleChange('month')}
+                                    onChange={this.handleChangeMonth}
                                 />
                             </Col>
                             <Col lg={4}>
@@ -104,7 +114,7 @@ class Tool extends Component {
                                     disabled={this.state.dataLoading}
                                     start={1970} end={2018}
                                     value={this.state.year}
-                                    onChange={this.makeHandleChange('year')}
+                                    onChange={this.handleChangeYear}
                                 />
                             </Col>
                             <Col lg={4}>
@@ -132,4 +142,4 @@ class Tool extends Component {
     }
 }
 
-export default Tool;
+export default withLifeCycleLogging.hoc()(Tool);

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { Grid, Row, Col } from 'react-bootstrap';
 
 import logger from '../../logger';
@@ -14,7 +14,7 @@ import DataViewer from '../DataViewer';
 import 'react-input-range/lib/css/index.css';
 import './Tool.css';
 
-class Tool extends Component {
+class Tool extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -16,8 +16,14 @@ import './Tool.css';
 class Tool extends Component {
     constructor(props) {
         super(props);
-        this.state = Tool.defaultState;
-        bindFunctions(this, 'handleIncrementYear handleIncrementMonth');
+        this.state = {
+            dataset: 'anomaly',
+            variable: 'precip',
+            year: 1990,
+            month: 6,
+            dataLoading: false,
+        };
+        bindFunctions(this, 'handleIncrementYear handleIncrementMonth handleDataIsLoading handleDataIsNotLoading');
     }
 
     makeHandleChange(item) {
@@ -38,6 +44,14 @@ class Tool extends Component {
         this.setState({month, year});
     }
 
+    handleDataIsLoading() {
+        this.setState({dataLoading: true});
+    }
+
+    handleDataIsNotLoading() {
+        this.setState({dataLoading: false});
+    }
+
     render() {
         logger.log(this);
         const isBaselineDataset = this.state.dataset === 'baseline';
@@ -50,6 +64,7 @@ class Tool extends Component {
                             <Col lg={2}/>
                             <Col lg={4}>
                                 <VariableSelector
+                                    disabled={this.state.dataLoading}
                                     value={this.state.variable}
                                     onChange={this.makeHandleChange('variable')}
                                 />
@@ -66,12 +81,14 @@ class Tool extends Component {
                         <Row>
                             <Col lg={8}>
                                 <MonthSelector
+                                    disabled={this.state.dataLoading}
                                     value={this.state.month}
                                     onChange={this.makeHandleChange('month')}
                                 />
                             </Col>
                             <Col lg={4}>
                                 <IncrementDecrement
+                                    disabled={this.state.dataLoading}
                                     id="month-increment"
                                     bsSize="xsmall"
                                     by={[1, 3, 6]}
@@ -83,6 +100,7 @@ class Tool extends Component {
                         <Row>
                             <Col lg={8}>
                                 <YearSelector
+                                    disabled={this.state.dataLoading}
                                     start={1970} end={2018}
                                     value={this.state.year}
                                     onChange={this.makeHandleChange('year')}
@@ -90,6 +108,7 @@ class Tool extends Component {
                             </Col>
                             <Col lg={4}>
                                 <IncrementDecrement
+                                    disabled={this.state.dataLoading}
                                     id="year-increment"
                                     bsSize="xsmall"
                                     by={[1, 2, 3, 4, 5, 10]}
@@ -101,6 +120,9 @@ class Tool extends Component {
                     <Col  lg={9}>
                         <DataViewer
                             {...pick(this.state, 'dataset variable year month')}
+                            onDataWillLoad={this.handleDataIsLoading}
+                            onDataDidLoad={this.handleDataIsNotLoading}
+                            onDataDidCatch={this.handleDataIsNotLoading}
                         />
                     </Col>
                 </Row>
@@ -108,12 +130,5 @@ class Tool extends Component {
         )
     }
 }
-
-Tool.defaultState = {
-    dataset: 'anomaly',
-    variable: 'precip',
-    year: 1990,
-    month: 6,
-};
 
 export default Tool;

--- a/src/components/VariableSelector/VariableSelector.js
+++ b/src/components/VariableSelector/VariableSelector.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
 
@@ -8,13 +8,14 @@ import RadioButtonSelector from '../RadioButtonSelector';
 import './VariableSelector.css';
 
 
-class VariableSelector extends Component {
+const variables = [
+    { value: 'precip', label: 'Precipitation', },
+    { value: 'tmin', label: <span>T<sub>min</sub></span>, },
+    { value: 'tmax', label: <span>T<sub>max</sub></span>, },
+];
+
+class VariableSelector extends PureComponent {
     render() {
-        const variables = [
-            { value: 'precip', label: 'Precipitation', },
-            { value: 'tmin', label: <span>T<sub>min</sub></span>, },
-            { value: 'tmax', label: <span>T<sub>max</sub></span>, },
-        ];
         return (
             <RadioButtonSelector
                 {...pick(this.props, 'className disabled value onChange')}

--- a/src/components/VariableSelector/VariableSelector.js
+++ b/src/components/VariableSelector/VariableSelector.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import RadioButtonSelector from '../RadioButtonSelector';
 import './VariableSelector.css';
@@ -58,4 +57,4 @@ VariableSelector.tooltips = {
     tmax: <Tooltip id="tmax">Monthly average of daily maximum temperature</Tooltip>,
 };
 
-export default withLifeCycleLogging.hoc()(VariableSelector);
+export default VariableSelector;

--- a/src/components/VariableSelector/VariableSelector.js
+++ b/src/components/VariableSelector/VariableSelector.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
+
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { pick } from '../utils';
 import RadioButtonSelector from '../RadioButtonSelector';
 import './VariableSelector.css';
@@ -55,4 +57,4 @@ VariableSelector.tooltips = {
     tmax: <Tooltip id="tmax">Monthly average of daily maximum temperature</Tooltip>,
 };
 
-export default VariableSelector;
+export default withLifeCycleLogging.hoc()(VariableSelector);

--- a/src/components/VariableSelector/VariableSelector.js
+++ b/src/components/VariableSelector/VariableSelector.js
@@ -41,7 +41,7 @@ class VariableSelector extends Component {
 }
 
 VariableSelector.propTypes = {
-    disabled: PropTypes.boolean,
+    disabled: PropTypes.bool,
     // Is control disabled
     value: PropTypes.string,
     // Current value of control

--- a/src/components/VariableSelector/VariableSelector.js
+++ b/src/components/VariableSelector/VariableSelector.js
@@ -15,10 +15,9 @@ class VariableSelector extends Component {
         ];
         return (
             <RadioButtonSelector
-                className={this.props.className}
+                {...pick(this.props, 'className disabled value onChange')}
                 name="variable"
                 options={variables}
-                {...pick(this.props, 'value onChange')}
             />
             // <div>
             //     <ToggleButtonGroup
@@ -42,8 +41,12 @@ class VariableSelector extends Component {
 }
 
 VariableSelector.propTypes = {
+    disabled: PropTypes.boolean,
+    // Is control disabled
     value: PropTypes.string,
+    // Current value of control
     onChange: PropTypes.func,
+    // Callback when new option selected
 };
 
 VariableSelector.tooltips = {

--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -1,6 +1,6 @@
 // TODO: YearSelector and MonthSelector are nearly identical. Use a HOC for them both.
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
@@ -11,7 +11,7 @@ import { bindFunctions, pick } from '../utils';
 import './YearSelector.css';
 
 
-class YearSelector extends Component {
+class YearSelector extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {

--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
+import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 
 import './YearSelector.css';
@@ -63,4 +64,4 @@ YearSelector.defaultProps = {
 };
 
 
-export default YearSelector;
+export default withLifeCycleLogging.hoc()(YearSelector);

--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
-import withLifeCycleLogging from '../../HOCs/withLifeCycleLogging';
 import { bindFunctions, pick } from '../utils';
 
 import './YearSelector.css';
@@ -64,4 +63,4 @@ YearSelector.defaultProps = {
 };
 
 
-export default withLifeCycleLogging.hoc()(YearSelector);
+export default YearSelector;

--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -44,7 +44,7 @@ class YearSelector extends Component {
 }
 
 YearSelector.propTypes = {
-    disabled: PropTypes.boolean,
+    disabled: PropTypes.bool,
     // Is control disabled
     start: PropTypes.number,
     // Start year

--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import InputRange from 'react-input-range';
 
-import { bindFunctions } from '../utils';
+import { bindFunctions, pick } from '../utils';
 
 import './YearSelector.css';
 
@@ -32,7 +32,7 @@ class YearSelector extends Component {
     render() {
         return (
             <InputRange
-                className={this.props.className}
+                {...pick(this.props, 'className disabled')}
                 minValue={this.props.start}
                 maxValue={this.props.end}
                 value={this.state.value}
@@ -44,6 +44,8 @@ class YearSelector extends Component {
 }
 
 YearSelector.propTypes = {
+    disabled: PropTypes.boolean,
+    // Is control disabled
     start: PropTypes.number,
     // Start year
     end: PropTypes.number,
@@ -55,6 +57,7 @@ YearSelector.propTypes = {
 };
 
 YearSelector.defaultProps = {
+    disabled: false,
     start: 1970,
     end: 2018,
 };

--- a/src/logger.js
+++ b/src/logger.js
@@ -76,4 +76,7 @@ const nameFromStackLine = /^\s*at (?:\w+\.)?(\w+) .*$/;
     Logger.prototype[name] = method;
 });
 
-export default new Logger();
+const logger = new Logger();
+logger.configure({active: !process.env.CI || process.env.CI === 'log'});
+
+export default logger;


### PR DESCRIPTION
Resolves #13 
Resolves #15 
Resolves https://github.com/pacificclimate/weather-anomaly-tool/issues/37

Logging is now dependent on the environment variable CI -- it on if CI is unset or if it is set to 'log'. Possibly not a good choice, but sufficient for now.

This PR also improves the withLifeCycleLogging HOC; a bit ironic, as it turns out that this HOC is made completely redundant by the React performance logging feature. Oh well.
