### PR TITLE
Set the default month/year to the most recently available month/year

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-REACT_APP_TILECACHE_URL=https://tile.pacificclimate.org/tilecache/tilecache.py
+REACT_APP_TILECACHE_URL=https://b.tile.pacificclimate.org/tilecache/tilecache.py
 REACT_APP_WADS_URL=https://services.pacificclimate.org/weather-anomaly

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -16,13 +16,21 @@ import './Tool.css';
 class Tool extends PureComponent {
     constructor(props) {
         super(props);
+
+        // Compute likely latest date of available data = current date - 15 d.
+        // This allows for cron jobs that run in first half of month.
+        // Subtract fewer/more days if cron jobs run earlier/later in month.
+        const msInDay = 24 * 60 * 60 * 1000;
+        const latestDataDate = new Date(Date.now() - 15 * msInDay);
+
         this.state = {
             dataset: 'anomaly',
             variable: 'precip',
-            year: 1990,
-            month: 6,
+            year: latestDataDate.getFullYear(),
+            month: latestDataDate.getMonth(),
             dataLoading: false,
         };
+
         bindFunctions(this, 'handleChangeVariable handleChangeDataset handleChangeMonth handleChangeYear handleIncrementYear handleIncrementMonth handleDataIsLoading handleDataIsNotLoading');
     }
 


### PR DESCRIPTION
Resolves #52 

Uses very simple method to select date: current date - 15 d, to allow for database-update cron job that runs in first half of month. Will be wrong a few days a month.