### PR TITLE
Update YearSelector.js

### DIFF
--- a/src/components/YearSelector/YearSelector.js
+++ b/src/components/YearSelector/YearSelector.js
@@ -59,7 +59,11 @@ YearSelector.propTypes = {
 YearSelector.defaultProps = {
     disabled: false,
     start: 1970,
-    end: 2018,
+    end: 2019,
+    //The default property for the year selector needs to dynamically track 
+    //the current year so that the tool appears up-to-date. Current deployment 
+    //shows 2018 as the max year. Using the +- increment/decrement buttons allows
+    //one to select 2019, but this is HIGHLY unintuitive.
 };
 
 


### PR DESCRIPTION
@ line 62, The default property for the year selector needs to dynamically track  the current year so that the tool appears up-to-date. Current deployment shows 2018 as the max year. Using the +- increment/decrement buttons allows one to select 2019, but this is HIGHLY non-intuitive. I was about to file an issue that the tool can't deliver 2019 output, but found that this is the actual issue.