### PR TITLE
Fix station marker rendering

### DIFF
--- a/src/components/DataMap/DataMap.js
+++ b/src/components/DataMap/DataMap.js
@@ -35,7 +35,7 @@ function uniqueKey(station) {
   return station.station_db_id.toString() + station.network_variable_name;
 }
 
-function StationLocationMarkers({ stations }) {
+function StationLocationMarkers({ type, stations }) {
   // Return a set of markers (<CircleMarker/>) for the locations of each
   // station in `props.station`. Icon markers `<Marker/>` don't work in this
   // environment. I think it is because Webpack isn't including the image
@@ -43,7 +43,7 @@ function StationLocationMarkers({ stations }) {
   // circle markers work.
   return stations.map(station =>
     <CircleMarker
-      key={uniqueKey(station)}
+      key={`loc-${type}-${uniqueKey(station)}`}
       center={{ lng: station.lon, lat: station.lat }}
       {...locationMarkerOptions}
     />
@@ -55,7 +55,7 @@ function StationDataMarkers({ variable, dataset, stations }) {
   // in `station`.
   return stations.map(station =>
     <CircleMarker
-      key={uniqueKey(station)}
+      key={`data-${variable}-${dataset}-${uniqueKey(station)}`}
       center={{ lng: station.lon, lat: station.lat }}
       {...dataMarkerOptions}
       color={stationColor(variable, dataset, station)}
@@ -130,6 +130,7 @@ class DataMap extends PureComponent {
           <LayersControl.Overlay name='Baseline stations'>
             <LayerGroup>
               <StationLocationMarkers
+                type="baseline"
                 stations={this.props.baseline}
               />
             </LayerGroup>
@@ -137,6 +138,7 @@ class DataMap extends PureComponent {
           <LayersControl.Overlay name='Monthly stations' checked>
             <LayerGroup>
               <StationLocationMarkers
+                type="monthly"
                 stations={this.props.monthly}
               />
             </LayerGroup>

--- a/src/components/Tool/Tool.js
+++ b/src/components/Tool/Tool.js
@@ -39,6 +39,8 @@ export default function Tool({
   const [dataset, setDataset] = useState('anomaly');
   const [variable, setVariable] = useState('precip');
   const [date, setDate] = useState(latestPossibleDataDate);
+  const [baseline, setBaseline] = useState(null);
+  const [monthly, setMonthly] = useState(null);
 
   // Determine latest date with data, and set date to it. This happens once,
   // on first render.
@@ -51,9 +53,10 @@ export default function Tool({
     });
   }, []);
 
-  const [baseline, setBaseline] = useState(null);  // Change to null
-  const [monthly, setMonthly] = useState(null);  // Change to null
-
+  // When variable or date changes, get data.
+  // (Both datasets are is retrieved for all values of `dataset`. This could
+  // be refined to get only the dataset(s) required by the value of `dataset`.)
+  // Consider splitting this into two separate effects, with an if on `dataset`.
   useEffect(() => {
     setBaseline(null);
     setMonthly(null);


### PR DESCRIPTION
React got better at optimizing rendering, which meant that our insufficiently-unique keys for the station markers caused the markers not to be updated correctly when Dataset is changed.