### PR TITLE
Convert to Zustand state management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-anomaly-tool",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-anomaly-tool",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@react-leaflet/core": "1.0.2",
@@ -28,7 +28,8 @@
         "react-scripts": "^4.0.3",
         "react-test-renderer": "^16.0.0",
         "svg-loaders-react": "^2.2.1",
-        "url-join": "^2.0.2"
+        "url-join": "^2.0.2",
+        "zustand": "^4.4.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -10601,9 +10602,11 @@
       }
     },
     "node_modules/immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "optional": true,
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -16528,6 +16531,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-dev-utils/node_modules/immer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -22052,6 +22064,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     }
   },
@@ -30036,9 +30083,11 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "optional": true,
+      "peer": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -34590,6 +34639,11 @@
             "slash": "^3.0.0"
           }
         },
+        "immer": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+          "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+        },
         "loader-utils": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
@@ -38976,6 +39030,22 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
+      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "dependencies": {
+        "use-sync-external-store": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+          "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+          "requires": {}
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-scripts": "^4.0.3",
     "react-test-renderer": "^16.0.0",
     "svg-loaders-react": "^2.2.1",
-    "url-join": "^2.0.2"
+    "url-join": "^2.0.2",
+    "zustand": "^4.4.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/controls/DatasetSelector/DatasetSelector.js
+++ b/src/components/controls/DatasetSelector/DatasetSelector.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import flow from 'lodash/fp/flow';
 import keys from 'lodash/fp/keys';
 import map from 'lodash/fp/map';

--- a/src/components/controls/DatasetSelector/DatasetSelector.js
+++ b/src/components/controls/DatasetSelector/DatasetSelector.js
@@ -6,19 +6,32 @@ import map from 'lodash/fp/map';
 
 import DatasetLabel from '../../datasets/DatasetLabel';
 import RadioButtonSelector from '../RadioButtonSelector';
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 
 function DatasetSelector(props) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
+
+  // TODO: Memoize
   const options = flow(
     keys,
     map(dataset =>
         ({ value: dataset, label: <DatasetLabel dataset={dataset}/> })
     ),
   )(config.datasets);
+
+  const dataset = useStore(state => state.dataset);
+  const setDataset = useStore(state => state.setDataset);
+
   return (
-    <RadioButtonSelector name="dataset" options={options} {...props}/>
+    <RadioButtonSelector
+      name="dataset"
+      options={options}
+      value={dataset}
+      onChange={setDataset}
+      styling={config.ui.datasetSelector.styling}
+      {...props}
+    />
   );
 }
 

--- a/src/components/controls/DatasetSelector/DatasetSelector.js
+++ b/src/components/controls/DatasetSelector/DatasetSelector.js
@@ -9,7 +9,7 @@ import RadioButtonSelector from '../RadioButtonSelector';
 import { useStore } from '../../../state-store';
 
 
-function DatasetSelector(props) {
+export default function DatasetSelector(props) {
   const config = useStore(state => state.config);
 
   // TODO: Memoize
@@ -34,10 +34,3 @@ function DatasetSelector(props) {
     />
   );
 }
-
-DatasetSelector.propTypes = {
-  value: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-};
-
-export default DatasetSelector;

--- a/src/components/controls/MonthIncrementDecrement/MonthIncrementDecrement.js
+++ b/src/components/controls/MonthIncrementDecrement/MonthIncrementDecrement.js
@@ -5,12 +5,12 @@ import { useStore } from '../../../state-store';
 export default function MonthIncrementDecrement(props) {
   const config = useStore(state => state.config);
   const incrementMonth = useStore(state => state.incrementMonth);
-  const isDataLoading = useStore(state => state.isDataLoading);
+  const isDataLoading = useStore(state => state.isDataLoading());
 
   return (
     <IncrementDecrement
       id="month-increment-decrement"
-      disabled={isDataLoading()}
+      disabled={isDataLoading}
       defaultBy={config.ui.monthIncrementDecrement.defaultBy}
       bys={config.ui.monthIncrementDecrement.by}
       onIncrement={incrementMonth}

--- a/src/components/controls/MonthIncrementDecrement/MonthIncrementDecrement.js
+++ b/src/components/controls/MonthIncrementDecrement/MonthIncrementDecrement.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import IncrementDecrement from '../../controls/IncrementDecrement';
+import { useStore } from '../../../state-store';
+
+export default function MonthIncrementDecrement(props) {
+  const config = useStore(state => state.config);
+  const incrementMonth = useStore(state => state.incrementMonth);
+  const isDataLoading = useStore(state => state.isDataLoading);
+
+  return (
+    <IncrementDecrement
+      id="month-increment-decrement"
+      disabled={isDataLoading()}
+      defaultBy={config.ui.monthIncrementDecrement.defaultBy}
+      bys={config.ui.monthIncrementDecrement.by}
+      onIncrement={incrementMonth}
+      styling={config.ui.monthIncrementDecrement.styling}
+    />
+
+  )
+}

--- a/src/components/controls/MonthIncrementDecrement/package.json
+++ b/src/components/controls/MonthIncrementDecrement/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "MonthIncrementDecrement",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./MonthIncrementDecrement.js"
+}

--- a/src/components/controls/MonthSelector/MonthSelector.js
+++ b/src/components/controls/MonthSelector/MonthSelector.js
@@ -1,15 +1,23 @@
 import React from 'react';
 import ThrottledInputRange from '../ThrottledInputRange';
+import { useStore } from '../../../state-store';
 
 const monthNames = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
 const formatLabel = value => monthNames[value];
 
 function MonthSelector(props) {
+  const date = useStore(state => state.date);
+  const setMonth = useStore(state => state.setMonth);
+  const isDataLoading = useStore(state => state.isDataLoading);
+
   return (
     <ThrottledInputRange
       minValue={0}
       maxValue={11}
       formatLabel={formatLabel}
+      disabled={isDataLoading()}
+      value={date.month()}
+      onChange={setMonth}
       {...props}
     />
   );

--- a/src/components/controls/MonthSelector/MonthSelector.js
+++ b/src/components/controls/MonthSelector/MonthSelector.js
@@ -5,22 +5,20 @@ import { useStore } from '../../../state-store';
 const monthNames = 'Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec'.split(' ');
 const formatLabel = value => monthNames[value];
 
-function MonthSelector(props) {
+export default function MonthSelector(props) {
   const date = useStore(state => state.date);
   const setMonth = useStore(state => state.setMonth);
-  const isDataLoading = useStore(state => state.isDataLoading);
+  const isDataLoading = useStore(state => state.isDataLoading());
 
   return (
     <ThrottledInputRange
       minValue={0}
       maxValue={11}
       formatLabel={formatLabel}
-      disabled={isDataLoading()}
+      disabled={isDataLoading}
       value={date.month()}
       onChange={setMonth}
       {...props}
     />
   );
 }
-
-export default MonthSelector;

--- a/src/components/controls/ThrottledInputRange/ThrottledInputRange.js
+++ b/src/components/controls/ThrottledInputRange/ThrottledInputRange.js
@@ -7,6 +7,8 @@ import InputRange from 'react-input-range';
 function ThrottledInputRange({ value, onChange, ...rest }) {
   const [intermediateValue, setIntermediateValue] = useState(value);
 
+  // TODO: This is probably better as useMemo.
+  // Update intermediate value whenever external value changes.
   useEffect(() => {
     setIntermediateValue(value);
   }, [value]);

--- a/src/components/controls/VariableSelector/VariableSelector.js
+++ b/src/components/controls/VariableSelector/VariableSelector.js
@@ -3,19 +3,34 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
 import keys from 'lodash/fp/keys';
 
-import { useConfigContext } from '../../main/ConfigContext';
 import RadioButtonSelector from '../RadioButtonSelector';
 import VariableLabel from '../../variables/VariableLabel';
+import { useStore } from '../../../state-store';
 
 
 function VariableSelector(props) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
+
+  // TODO: Memoize variableOptions
   const variableKeys = keys(config?.variables);
   const variableOptions = variableKeys.map(
     value => ({ value, label: <VariableLabel variable={value}/> })
   );
+
+  const variable = useStore(state => state.variable);
+  const setVariable = useStore(state => state.setVariable);
+  const isDataLoading = useStore(state => state.isDataLoading);
+
   return (
-    <RadioButtonSelector options={variableOptions} name="variable" {...props} />
+    <RadioButtonSelector
+      options={variableOptions}
+      name="variable"
+      disabled={isDataLoading()}
+      value={variable}
+      onChange={setVariable}
+      styling={config.ui.variableSelector.styling}
+      {...props}
+    />
   );
 }
 

--- a/src/components/controls/VariableSelector/VariableSelector.js
+++ b/src/components/controls/VariableSelector/VariableSelector.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Tooltip } from 'react-bootstrap';
 import keys from 'lodash/fp/keys';
 

--- a/src/components/controls/VariableSelector/VariableSelector.js
+++ b/src/components/controls/VariableSelector/VariableSelector.js
@@ -19,13 +19,13 @@ function VariableSelector(props) {
 
   const variable = useStore(state => state.variable);
   const setVariable = useStore(state => state.setVariable);
-  const isDataLoading = useStore(state => state.isDataLoading);
+  const isDataLoading = useStore(state => state.isDataLoading());
 
   return (
     <RadioButtonSelector
       options={variableOptions}
       name="variable"
-      disabled={isDataLoading()}
+      disabled={isDataLoading}
       value={variable}
       onChange={setVariable}
       styling={config.ui.variableSelector.styling}
@@ -33,15 +33,6 @@ function VariableSelector(props) {
     />
   );
 }
-
-VariableSelector.propTypes = {
-  disabled: PropTypes.bool,
-  // Is control disabled
-  value: PropTypes.string,
-  // Current value of control
-  onChange: PropTypes.func,
-  // Callback when new option selected
-};
 
 VariableSelector.tooltips = {
   precip: <Tooltip id="precip">Monthly total precipitation</Tooltip>,

--- a/src/components/controls/YearIncrementDecrement/YearIncrementDecrement.js
+++ b/src/components/controls/YearIncrementDecrement/YearIncrementDecrement.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import IncrementDecrement from '../../controls/IncrementDecrement';
+import { useStore } from '../../../state-store';
+
+export default function YearIncrementDecrement(props) {
+  const config = useStore(state => state.config);
+  const incrementYear = useStore(state => state.incrementYear);
+  const isDataLoading = useStore(state => state.isDataLoading);
+
+  return (
+    <IncrementDecrement
+      id="year-increment-decrement"
+      disabled={isDataLoading()}
+      defaultBy={config.ui.monthIncrementDecrement.defaultBy}
+      bys={config.ui.monthIncrementDecrement.by}
+      onIncrement={incrementYear}
+      styling={config.ui.monthIncrementDecrement.styling}
+    />
+
+  )
+}

--- a/src/components/controls/YearIncrementDecrement/YearIncrementDecrement.js
+++ b/src/components/controls/YearIncrementDecrement/YearIncrementDecrement.js
@@ -5,12 +5,12 @@ import { useStore } from '../../../state-store';
 export default function YearIncrementDecrement(props) {
   const config = useStore(state => state.config);
   const incrementYear = useStore(state => state.incrementYear);
-  const isDataLoading = useStore(state => state.isDataLoading);
+  const isDataLoading = useStore(state => state.isDataLoading());
 
   return (
     <IncrementDecrement
       id="year-increment-decrement"
-      disabled={isDataLoading()}
+      disabled={isDataLoading}
       defaultBy={config.ui.monthIncrementDecrement.defaultBy}
       bys={config.ui.monthIncrementDecrement.by}
       onIncrement={incrementYear}

--- a/src/components/controls/YearIncrementDecrement/package.json
+++ b/src/components/controls/YearIncrementDecrement/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "YearIncrementDecrement",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./YearIncrementDecrement.js"
+}

--- a/src/components/controls/YearSelector/YearSelector.js
+++ b/src/components/controls/YearSelector/YearSelector.js
@@ -5,7 +5,7 @@ import { latestPossibleDataDate, useStore } from '../../../state-store';
 function YearSelector(props) {
   const date = useStore(state => state.date);
   const setYear = useStore(state => state.setYear);
-  const isDataLoading = useStore(state => state.isDataLoading);
+  const isDataLoading = useStore(state => state.isDataLoading());
 
   return (
     <ThrottledInputRange

--- a/src/components/controls/YearSelector/YearSelector.js
+++ b/src/components/controls/YearSelector/YearSelector.js
@@ -1,9 +1,21 @@
 import React from 'react';
 import ThrottledInputRange from '../ThrottledInputRange';
+import { latestPossibleDataDate, useStore } from '../../../state-store';
 
 function YearSelector(props) {
+  const date = useStore(state => state.date);
+  const setYear = useStore(state => state.setYear);
+  const isDataLoading = useStore(state => state.isDataLoading);
+
   return (
-    <ThrottledInputRange {...props} />
+    <ThrottledInputRange
+      disabled={isDataLoading}
+      minValue={1970}
+      maxValue={latestPossibleDataDate.year()}
+      value={date.year()}
+      onChange={setYear}
+      {...props}
+    />
   );
 }
 

--- a/src/components/datasets/DatasetLabel/DatasetLabel.js
+++ b/src/components/datasets/DatasetLabel/DatasetLabel.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 export default function DatasetLabel({ dataset }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
   return (
     <span dangerouslySetInnerHTML={{
       __html: config?.datasets?.[dataset]?.label ?? dataset

--- a/src/components/main/App/App.js
+++ b/src/components/main/App/App.js
@@ -12,42 +12,34 @@ logger.configure({ active: true });
 
 function App() {
   const initialize = useStore(state => state.initialize);
-  const config = useStore(state => state.config);
-  const configErrorMessage = useStore(state => state.configError);
+  const isConfigLoaded = useStore(state => state.isConfigLoaded());
+  const configError = useStore(state => state.configError);
 
-  // Initialize must be invoked before any items dependent on context.
+  // Initialize must be invoked before any items dependent on config.
+  // Done once, at startup.
   useEffect(() => {
     initialize({
-        defaultConfig: {
-          // TODO
-        },
-        requiredConfigKeys: [
-          // TODO
-        ],
-      });
-  });
+      configOpts: {
+          dfault: {
+            // TODO
+          },
+          requiredKeys: [
+            // TODO
+          ],
+        }
+    });
+  }, []);
 
-  // Now in state store
-  // must be invoked before any other items dependent on context.
-  // const [config, configErrorMessage] = useFetchConfigContext({
-  //   defaultConfig: {
-  //     // TODO
-  //   },
-  //   requiredConfigKeys: [
-  //     // TODO
-  //   ],
-  // });
-
-  if (configErrorMessage !== null) {
+  if (configError !== null) {
     // TODO: Improve presentation
     return (
       <div>
-        <div>{configErrorMessage}</div>
+        <div>{configError}</div>
       </div>
     )
   }
 
-  if (config === null) {
+  if (!isConfigLoaded) {
     // TODO: Replace with spinner
     return <div>Loading configuration...</div>
   }

--- a/src/components/main/App/App.js
+++ b/src/components/main/App/App.js
@@ -1,25 +1,42 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Container } from 'react-bootstrap';
 
 import logger from '../../../logger';
 import Header from '../Header';
 import Tool from '../Tool'
-import ConfigContext, { useFetchConfigContext } from '../ConfigContext';
 
 import './App.css';
+import { useStore } from '../../../state-store';
 
 logger.configure({ active: true });
 
 function App() {
-  // must be invoked before any other items dependent on context.
-  const [config, configErrorMessage] = useFetchConfigContext({
-    defaultConfig: {
-      // TODO
-    },
-    requiredConfigKeys: [
-      // TODO
-    ],
+  const initialize = useStore(state => state.initialize);
+  const config = useStore(state => state.config);
+  const configErrorMessage = useStore(state => state.configError);
+
+  // Initialize must be invoked before any items dependent on context.
+  useEffect(() => {
+    initialize({
+        defaultConfig: {
+          // TODO
+        },
+        requiredConfigKeys: [
+          // TODO
+        ],
+      });
   });
+
+  // Now in state store
+  // must be invoked before any other items dependent on context.
+  // const [config, configErrorMessage] = useFetchConfigContext({
+  //   defaultConfig: {
+  //     // TODO
+  //   },
+  //   requiredConfigKeys: [
+  //     // TODO
+  //   ],
+  // });
 
   if (configErrorMessage !== null) {
     // TODO: Improve presentation
@@ -36,12 +53,10 @@ function App() {
   }
 
   return (
-    <ConfigContext.Provider value={config}>
-      <Container fluid className="App">
-        <Header/>
-        <Tool/>
-      </Container>
-    </ConfigContext.Provider>
+    <Container fluid className="App">
+      <Header/>
+      <Tool/>
+    </Container>
   );
 }
 

--- a/src/components/main/Header/Header.js
+++ b/src/components/main/Header/Header.js
@@ -3,10 +3,10 @@ import { Row, Col } from 'react-bootstrap';
 import logo from './logo.png';
 
 import './Header.css';
-import { useConfigContext } from '../ConfigContext';
+import { useStore } from '../../../state-store';
 
 export default function Header() {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
   return (
     <Row className={'Header'}>
       <Col lg={3} className="text-left">

--- a/src/components/main/Tool/Tool.js
+++ b/src/components/main/Tool/Tool.js
@@ -16,7 +16,6 @@ import './Tool.css';
 
 
 export default function Tool() {
-  const initialize = useStore(state => state.initialize);
   const isBaselineDataset = useStore(state => state.isBaselineDataset);
 
   // Subsumed in state store, not used in this component
@@ -25,10 +24,6 @@ export default function Tool() {
   // const [date, setDate] = useState(latestPossibleDataDate);
   // const [baseline, setBaseline] = useState(null);
   // const [monthly, setMonthly] = useState(null);
-
-  useEffect(() => {
-    initialize();
-  });
 
   // Part of initialize
   // // Determine latest date with data, and set date to it. This happens once,

--- a/src/components/main/Tool/Tool.js
+++ b/src/components/main/Tool/Tool.js
@@ -1,96 +1,85 @@
 import React, { useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
-import moment from 'moment';
 
 import DatasetSelector from '../../controls/DatasetSelector'
 import VariableSelector from '../../controls/VariableSelector'
 import YearSelector from '../../controls/YearSelector';
 import MonthSelector from '../../controls/MonthSelector';
-import IncrementDecrement from '../../controls/IncrementDecrement';
-import ColourScale from '../../map/ColourScale';
-import DataMap from '../../map/DataMap';
-import VariableTitle from '../../variables/VariableTitle';
+import MonthIncrementDecrement from '../../controls/MonthIncrementDecrement';
+import YearIncrementDecrement from '../../controls/YearIncrementDecrement';
+import DataDisplay from '../../map/DataDisplay';
 
-import { getBaselineData, getLastDateWithDataBefore, getMonthlyData }
-  from '../../../data-services/weather-anomaly-data-service';
-import { useConfigContext } from '../ConfigContext';
+import { useStore } from '../../../state-store';
 
 import 'react-input-range/lib/css/index.css';
 import './Tool.css';
 
 
-// Note: We use package `moment` for date arithmetic. It is excellent but it
-// *mutates* its objects. We are using functional components,
-// which require values whose identity changes when their value is changed,
-// i.e., a new object. Therefore every change to a `moment` date object should
-// be preceded by `.clone()`; for example, `y = x.clone().subtract(1, 'month')`
-// yields a new moment object with a value 1 month before the original `x`
-// object. `x` is unchanged by this operation, and `y` is a different object
-// than `x`.
-
-// Compute likely latest possible date of available data = current date - 15 d.
-// This allows for cron jobs that run in first half of month.
-// Subtract fewer/more days if cron jobs run earlier/later in month.
-// But it is not guaranteed that there is data for this date; that can only be
-// determined by consulting the backend.
-const latestPossibleDataDate = moment().subtract(15, 'days');
-
 export default function Tool() {
-  const config = useConfigContext();
-  const wadsUrl = config.backends.weatherAnomalyDataService;
+  const initialize = useStore(state => state.initialize);
+  const isBaselineDataset = useStore(state => state.isBaselineDataset);
 
-  const [variable, setVariable] = useState(config.ui.variableSelector.initial);
-  const [dataset, setDataset] = useState(config.ui.datasetSelector.initial);
-  const [date, setDate] = useState(latestPossibleDataDate);
-  const [baseline, setBaseline] = useState(null);
-  const [monthly, setMonthly] = useState(null);
+  // Subsumed in state store, not used in this component
+  // const [variable, setVariable] = useState(config.ui.variableSelector.initial);
+  // const [dataset, setDataset] = useState(config.ui.datasetSelector.initial);
+  // const [date, setDate] = useState(latestPossibleDataDate);
+  // const [baseline, setBaseline] = useState(null);
+  // const [monthly, setMonthly] = useState(null);
 
-  // Determine latest date with data, and set date to it. This happens once,
-  // on first render.
   useEffect(() => {
-    setBaseline(null);
-    setMonthly(null);
-    getLastDateWithDataBefore(variable, date, wadsUrl)
-    .then(date => {
-      setDate(date);
-    });
-  }, []);
+    initialize();
+  });
 
-  // When variable or date changes, get data.
-  // (Both datasets are is retrieved for all values of `dataset`. This could
-  // be refined to get only the dataset(s) required by the value of `dataset`.)
-  // Consider splitting this into two separate effects, with an if on `dataset`.
-  useEffect(() => {
-    setBaseline(null);
-    setMonthly(null);
-    getBaselineData(variable, date, wadsUrl)
-    .then(r => {
-      setBaseline(r.data);
-    });
-    getMonthlyData(variable, date, wadsUrl)
-    .then(r => {
-      setMonthly(r.data);
-    });
-  }, [variable, date]);
+  // Part of initialize
+  // // Determine latest date with data, and set date to it. This happens once,
+  // // on first render.
+  // useEffect(() => {
+  //   setBaseline(null);
+  //   setMonthly(null);
+  //   getLastDateWithDataBefore(variable, date, wadsUrl)
+  //   .then(date => {
+  //     setDate(date);
+  //   });
+  // }, []);
 
-  const handleChangeMonth = (month) => {
-    setDate((date) => date.clone().month(month));
-  };
+  // Folded into store actions
+  // // When variable or date changes, get data.
+  // // (Both datasets are is retrieved for all values of `dataset`. This could
+  // // be refined to get only the dataset(s) required by the value of `dataset`.)
+  // // Consider splitting this into two separate effects, with an if on `dataset`.
+  // useEffect(() => {
+  //   setBaseline(null);
+  //   setMonthly(null);
+  //   getBaselineData(variable, date, wadsUrl)
+  //   .then(r => {
+  //     setBaseline(r.data);
+  //   });
+  //   getMonthlyData(variable, date, wadsUrl)
+  //   .then(r => {
+  //     setMonthly(r.data);
+  //   });
+  // }, [variable, date]);
 
-  const handleChangeYear = (year) => {
-    setDate((date) => date.clone().year(year));
-  };
+  // Handlers moved to state store actions
+  // const handleChangeMonth = (month) => {
+  //   setDate((date) => date.clone().month(month));
+  // };
+  //
+  // const handleChangeYear = (year) => {
+  //   setDate((date) => date.clone().year(year));
+  // };
+  //
+  // const handleIncrementYear = (by) => {
+  //   setDate((date) => date.clone().add(by, 'year'));
+  // };
+  //
+  // const handleIncrementMonth = (by) => {
+  //   setDate((date) => date.clone().add(by, 'month'));
+  // };
 
-  const handleIncrementYear = (by) => {
-    setDate((date) => date.clone().add(by, 'year'));
-  };
-
-  const handleIncrementMonth = (by) => {
-    setDate((date) => date.clone().add(by, 'month'));
-  };
-
-  const isDataLoading = baseline === null || monthly === null;
-  const isBaselineDataset = dataset === 'baseline';
+  // Computed values moved to state store actions
+  // const isDataLoading = baseline === null || monthly === null;
+  // const isBaselineDataset = dataset === 'baseline';
 
   const displayColWidths = { xs: 12, md: "auto" };
   const rowSpacing = "mt-3"
@@ -102,92 +91,40 @@ export default function Tool() {
           <Row className={rowSpacing}><Col>Display</Col></Row>
           <Row className={`${rowSpacing} justify-content-md-center`}>
             <Col {...displayColWidths} className="mb-sm-2 mb-lg-0">
-              <VariableSelector
-                vertical
-                disabled={isDataLoading}
-                value={variable}
-                onChange={setVariable}
-                styling={config.ui.variableSelector.styling}
-              />
+              <VariableSelector vertical/>
             </Col>
             <Col {...displayColWidths}>
-              <DatasetSelector
-                vertical
-                value={dataset}
-                onChange={setDataset}
-                styling={config.ui.datasetSelector.styling}
-              />
+              <DatasetSelector vertical/>
             </Col>
           </Row>
           <Row className={rowSpacing}><Col>for</Col></Row>
           <Row className={`${rowSpacing} mt-1 ps-2 pe-5`}>
             <Col>
-              <MonthSelector
-                disabled={isDataLoading}
-                value={date.month()}
-                onChange={handleChangeMonth}
-              />
+              <MonthSelector/>
             </Col>
           </Row>
           <Row className="mt-0">
             <Col>
-              <IncrementDecrement
-                id="month-increment"
-                disabled={isDataLoading}
-                defaultBy={config.ui.monthIncrementDecrement.defaultBy}
-                bys={config.ui.monthIncrementDecrement.by}
-                onIncrement={handleIncrementMonth}
-                styling={config.ui.monthIncrementDecrement.styling}
-              />
+              <MonthIncrementDecrement/>
             </Col>
           </Row>
-          {!isBaselineDataset &&
+          {!isBaselineDataset() &&
             <React.Fragment>
               <Row className={`${rowSpacing} ps-2 pe-5`}>
                 <Col>
-                    <YearSelector
-                      disabled={isDataLoading}
-                      minValue={1970}
-                      maxValue={latestPossibleDataDate.year()}
-                      value={date.year()}
-                      onChange={handleChangeYear}
-                    />
+                    <YearSelector/>
                 </Col>
               </Row>
               <Row className="mt-0">
                 <Col>
-                  <IncrementDecrement
-                    id="year-increment"
-                    disabled={isDataLoading}
-                    defaultBy={config.ui.yearIncrementDecrement.defaultBy}
-                    bys={config.ui.yearIncrementDecrement.by}
-                    onIncrement={handleIncrementYear}
-                    styling={config.ui.yearIncrementDecrement.styling}
-                  />
+                  <YearIncrementDecrement/>
                 </Col>
               </Row>
             </React.Fragment>
           }
         </Col>
         <Col xs={9}>
-          <Row className="my-1">
-            <Col>
-              <VariableTitle variable={variable} dataset={dataset}/>
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <ColourScale variable={variable} dataset={dataset}/>
-            </Col>
-          </Row>
-          <Row>
-            <DataMap
-              dataset={dataset}
-              variable={variable}
-              baseline={baseline}
-              monthly={monthly}
-            />
-          </Row>
+          <DataDisplay/>
         </Col>
       </Row>
     </React.Fragment>

--- a/src/components/main/Tool/Tool.js
+++ b/src/components/main/Tool/Tool.js
@@ -16,7 +16,7 @@ import './Tool.css';
 
 
 export default function Tool() {
-  const isBaselineDataset = useStore(state => state.isBaselineDataset);
+  const isBaselineDataset = useStore(state => state.isBaselineDataset());
 
   // Subsumed in state store, not used in this component
   // const [variable, setVariable] = useState(config.ui.variableSelector.initial);
@@ -103,7 +103,7 @@ export default function Tool() {
               <MonthIncrementDecrement/>
             </Col>
           </Row>
-          {!isBaselineDataset() &&
+          {!isBaselineDataset &&
             <React.Fragment>
               <Row className={`${rowSpacing} ps-2 pe-5`}>
                 <Col>

--- a/src/components/main/Tool/Tool.js
+++ b/src/components/main/Tool/Tool.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Col, Row } from 'react-bootstrap';
 
 import DatasetSelector from '../../controls/DatasetSelector'
@@ -18,64 +18,7 @@ import './Tool.css';
 export default function Tool() {
   const isBaselineDataset = useStore(state => state.isBaselineDataset());
 
-  // Subsumed in state store, not used in this component
-  // const [variable, setVariable] = useState(config.ui.variableSelector.initial);
-  // const [dataset, setDataset] = useState(config.ui.datasetSelector.initial);
-  // const [date, setDate] = useState(latestPossibleDataDate);
-  // const [baseline, setBaseline] = useState(null);
-  // const [monthly, setMonthly] = useState(null);
-
-  // Part of initialize
-  // // Determine latest date with data, and set date to it. This happens once,
-  // // on first render.
-  // useEffect(() => {
-  //   setBaseline(null);
-  //   setMonthly(null);
-  //   getLastDateWithDataBefore(variable, date, wadsUrl)
-  //   .then(date => {
-  //     setDate(date);
-  //   });
-  // }, []);
-
-  // Folded into store actions
-  // // When variable or date changes, get data.
-  // // (Both datasets are is retrieved for all values of `dataset`. This could
-  // // be refined to get only the dataset(s) required by the value of `dataset`.)
-  // // Consider splitting this into two separate effects, with an if on `dataset`.
-  // useEffect(() => {
-  //   setBaseline(null);
-  //   setMonthly(null);
-  //   getBaselineData(variable, date, wadsUrl)
-  //   .then(r => {
-  //     setBaseline(r.data);
-  //   });
-  //   getMonthlyData(variable, date, wadsUrl)
-  //   .then(r => {
-  //     setMonthly(r.data);
-  //   });
-  // }, [variable, date]);
-
-  // Handlers moved to state store actions
-  // const handleChangeMonth = (month) => {
-  //   setDate((date) => date.clone().month(month));
-  // };
-  //
-  // const handleChangeYear = (year) => {
-  //   setDate((date) => date.clone().year(year));
-  // };
-  //
-  // const handleIncrementYear = (by) => {
-  //   setDate((date) => date.clone().add(by, 'year'));
-  // };
-  //
-  // const handleIncrementMonth = (by) => {
-  //   setDate((date) => date.clone().add(by, 'month'));
-  // };
-
-  // Computed values moved to state store actions
-  // const isDataLoading = baseline === null || monthly === null;
-  // const isBaselineDataset = dataset === 'baseline';
-
+  // TODO: Move into config?
   const displayColWidths = { xs: 12, md: "auto" };
   const rowSpacing = "mt-3"
 

--- a/src/components/map/ColourScale/ColourScale.js
+++ b/src/components/map/ColourScale/ColourScale.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 
 export default function ColourScale({
@@ -23,7 +23,7 @@ export default function ColourScale({
     return csItem.annotation;
   },
 }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
 
   const colourScale = config.colourScales[variable][dataset];
   const numItems = colourScale.length;

--- a/src/components/map/DataDisplay/DataDisplay.js
+++ b/src/components/map/DataDisplay/DataDisplay.js
@@ -11,8 +11,9 @@ export default function DataDisplay() {
   const dataset = useStore(state => state.dataset);
   const baseline = useStore(state => state.baseline);
   const monthly = useStore(state => state.monthly);
+  const hasValidState = useStore(state => state.hasValidState());
 
-  return (
+  return hasValidState && (
     <>
       <Row className="my-1">
         <Col>

--- a/src/components/map/DataDisplay/DataDisplay.js
+++ b/src/components/map/DataDisplay/DataDisplay.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Col, Row } from 'react-bootstrap';
+
+import ColourScale from '../../map/ColourScale';
+import DataMap from '../../map/DataMap';
+import VariableTitle from '../../variables/VariableTitle';
+import { useStore } from '../../../state-store';
+
+export default function DataDisplay() {
+  const variable = useStore(state => state.variable);
+  const dataset = useStore(state => state.dataset);
+  const baseline = useStore(state => state.baseline);
+  const monthly = useStore(state => state.monthly);
+
+  return (
+    <>
+      <Row className="my-1">
+        <Col>
+          <VariableTitle variable={variable} dataset={dataset}/>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <ColourScale variable={variable} dataset={dataset}/>
+        </Col>
+      </Row>
+      <Row>
+        <DataMap
+          dataset={dataset}
+          variable={variable}
+          baseline={baseline}
+          monthly={monthly}
+        />
+      </Row>
+    </>
+  );
+}

--- a/src/components/map/DataDisplay/package.json
+++ b/src/components/map/DataDisplay/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "DataDisplay",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./DataDisplay.js"
+}

--- a/src/components/map/DataMap/DataMap.js
+++ b/src/components/map/DataMap/DataMap.js
@@ -10,14 +10,14 @@ import compact from 'lodash/fp/compact';
 
 import { BCBaseMap } from 'pcic-react-leaflet-components';
 import './DataMap.css';
-import { useConfigContext } from '../../main/ConfigContext';
 import MapSpinner from '../MapSpinner';
 import StationDataMarkers from '../StationDataMarkers';
 import StationLocationMarkers from '../StationLocationMarkers';
+import { useStore } from '../../../state-store';
 
 
 export default function DataMap({ dataset, variable, monthly, baseline }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
 
   const stationsForDataset = useMemo(
     () => {

--- a/src/components/map/StationPopup/StationPopup.js
+++ b/src/components/map/StationPopup/StationPopup.js
@@ -4,7 +4,7 @@ import { Popup } from 'react-leaflet'
 
 import VariableLabel from '../../variables/VariableLabel';
 import VariableUnits from '../../variables/VariableUnits';
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 
 export default function StationPopup({
@@ -24,7 +24,7 @@ export default function StationPopup({
     departure,
   },
 }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
   const units = <VariableUnits variable={variable}/>;
   const decimalPlaces = config?.variables?.[variable]?.decimalPlaces;
 

--- a/src/components/variables/VariableLabel/VariableLabel.js
+++ b/src/components/variables/VariableLabel/VariableLabel.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 export default function VariableLabel({ variable }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
   return <span dangerouslySetInnerHTML={{
     __html: config?.variables?.[variable]?.label || `${variable}`
   }}/> ;

--- a/src/components/variables/VariableTitle/VariableTitle.js
+++ b/src/components/variables/VariableTitle/VariableTitle.js
@@ -1,3 +1,7 @@
+// Variable title: Long-form description of variable for titling displays of
+// data. It is generic, meaning it does not subscribe to the state store, but
+// accepts arbitrary inputs for these values.
+
 import React from 'react';
 import compact from 'lodash/fp/compact';
 import flow from 'lodash/fp/flow';
@@ -6,7 +10,6 @@ import { alternate } from '../../utils';
 import VariableLabel from '../VariableLabel';
 import VariableUnits from '../VariableUnits';
 import DatasetLabel from '../../datasets/DatasetLabel';
-import { useConfigContext } from '../../main/ConfigContext';
 
 
 export default function VariableTitle({

--- a/src/components/variables/VariableUnits/VariableUnits.js
+++ b/src/components/variables/VariableUnits/VariableUnits.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useConfigContext } from '../../main/ConfigContext';
+import { useStore } from '../../../state-store';
 
 export default function VariableUnits({ variable }) {
-  const config = useConfigContext();
+  const config = useStore(state => state.config);
   return (
     <span dangerouslySetInnerHTML={{
       __html: config?.variables?.[variable]?.units ?? 'bar'

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -1,0 +1,174 @@
+// This is the Zustand state store for the app.
+
+// Note: We use package `moment` for date arithmetic. It is excellent but it
+// *mutates* its objects. We are using functional components,
+// which require values whose identity changes when their value is changed,
+// i.e., a new object. Therefore, every change to a `moment` date object should
+// be preceded by `.clone()`; for example, `y = x.clone().subtract(1, 'month')`
+// yields a new moment object with a value 1 month before the `x` object. `x` is
+// unchanged by this operation; `y` is a different object than `x`.
+
+
+import { create } from 'zustand';
+import moment from 'moment/moment';
+import {
+  getBaselineData,
+  getLastDateWithDataBefore,
+  getMonthlyData,
+} from './data-services/weather-anomaly-data-service';
+import axios from 'axios';
+import yaml from 'js-yaml';
+import filter from 'lodash/fp/filter';
+import isUndefined from 'lodash/fp/isUndefined';
+
+
+// Comments: 
+// - The store knows a lot here, such as the structure of config and the names 
+//    and usages of the data services. OK? Too much dependency?
+//
+
+// Likely latest possible date of available data = current date - 15 d.
+// This allows for cron jobs that run in first half of month.
+// Subtract fewer/more days if cron jobs run earlier/later in month.
+// But it is not guaranteed that there is data for this date; that can only be
+// determined by consulting the backend.
+export const latestPossibleDataDate = moment().subtract(15, 'days');
+
+
+export const useStore = create((set, get) => ({
+  // States
+  config: null,
+  configError: null,
+
+  variable: null,  // config.ui.variableSelector.initial
+  dataset: null,  // config.ui.datasetSelector.initial
+  baseline: null,
+  monthly: null,
+  date: latestPossibleDataDate,  // TODO: Put subtraction value in config
+
+  // Actions
+
+  // Important: Wrap in useEffect
+  // Load configuration
+  // This should not be called except by initialize.
+  _loadConfig: ({ defaultConfig= {}, requiredConfigKeys = []}) => {
+    return axios.get(`${process.env.PUBLIC_URL}/config.yaml`)
+    .then(response => {
+      // Extend default config with values loaded from config.yaml
+      let config;
+      try {
+        const customConfig = yaml.load(response.data);
+        config = { ...defaultConfig, ...customConfig };
+      } catch (error) {
+        set({
+          configError: (
+            <div>Error parsing config.yaml: <pre>{error.toString()}</pre></div>
+          )
+        });
+        throw error;
+      }
+
+      // Check for required config keys (we don't check value types, yet)
+      const missingRequiredKeys = filter(
+        key => isUndefined(config[key]), requiredConfigKeys
+      );
+      if (missingRequiredKeys.length > 0) {
+        const configErrorMsg = (
+          `Error in config.yaml: The following keys must have values, 
+          but do not: ${missingRequiredKeys}`
+        );
+        set({ configError: (<div>{configErrorMsg}</div>) });
+        throw new Error(configErrorMsg);
+      }
+
+      // TODO: Is there really any value in this?
+      //  Alternatively, just transfer everything in process.env here.
+      //  None of that makes much sense ...
+      // Extend config with some env var values
+      config.appVersion = process.env.REACT_APP_APP_VERSION ?? "unknown";
+
+      // Update the config state.
+      set({ config });
+    })
+    .catch(error => {
+      set({
+        configError: (
+          <div>Error fetching configuration: <pre>{error.toString()}</pre></div>
+        )
+      });
+      throw error;
+    });
+  },
+
+  // Important: Wrap in useEffect
+  // Initialize state from config and other async data sources.
+  initialize: () => {
+    // TODO: This can probably be done more nicely with async/await.
+    get()._loadConfig().then(() => {
+      // TODO: return config from _loadConfig as well as setting
+      //  state.config. Would be neater.
+      const config = get().config;
+      const wadsUrl = config.backends.weatherAnomalyDataService;
+      const variable = config.ui.variableSelector.initial;
+      const dataset = config.ui.datasetSelector.initial;
+      set({ variable, dataset });
+      getLastDateWithDataBefore(variable, latestPossibleDataDate, wadsUrl)
+      .then(date => {
+        // Note: This will also fetch the data for this date (and variable).
+        // We only want to do this once, so we don't call setVariable also.
+        get().setDate(date);
+      });
+    });
+  },
+
+  // Important: Wrap in useEffect
+  // Set the variable and load the data associated with it.
+  setVariable: (variable) => {
+    set({ variable });
+    get().getData();
+  },
+
+  // Important: Wrap in useEffect
+  // Set the date and load the data associated with it.
+  setDate: (date) => {
+    set({ date });
+    get().getData();
+  },
+
+  // Important: Wrap in useEffect
+  // Fetch baseline and monthly data for current setting of variable and date.
+  getData: () => {
+    const wadsUrl = get().config.backends.weatherAnomalyDataService;
+    set({ baseline: null, monthly: null });
+    getBaselineData(get().variable, get().date, wadsUrl)
+    .then(r => {
+      set({ baseline: r.data });
+    });
+    getMonthlyData(get().variable, get().date, wadsUrl)
+    .then(r => {
+      set({ monthly: r.data });
+    });
+  },
+
+  isDataLoading: () => get().baseline === null || get().monthly === null,
+
+  isBaselineDataset: () => dataset === 'baseline',
+  
+  setYear: year => {
+    get().setDate(get().date.clone().year(year));
+  },
+
+  incrementYear: by => {
+    get().setDate(get().date.clone().add(by, 'year'));
+  },
+
+  setMonth: month => {
+    get().setDate(get().date.clone().month(month));
+  },
+
+  incrementMonth: by => {
+    get().setDate(get().date.clone().add(by, 'month'));
+  },
+
+  setBaseline: baseline => set({ baseline }),
+}))

--- a/src/state-store.js
+++ b/src/state-store.js
@@ -102,6 +102,7 @@ export const useStore = create((set, get) => ({
 
   // Important: Wrap in useEffect
   // Initialize state from config and other async data sources.
+  // TODO: Add params and pass thru to _loadConfig
   initialize: () => {
     // TODO: This can probably be done more nicely with async/await.
     get()._loadConfig().then(() => {


### PR DESCRIPTION
This was very instructive, and successful. Thoughts, comments, notes:

- With Zustand, you move all your state-related logic into the store. Advantages:
  - All state logic (actions) is right next to state definitions.
  - State logic can easily use other parts of state logic, because it too is right there.
  - Components do not need to track detailed state logic or changes to it, only changes to the actions API (action functions and their signatures). This simplifies components.
  - State logic is easy to reuse across components: just get it out of the store.
  - It imposes a certain discipline on the conception and use of state. Bad state management becomes much more obvious, and more obvious how to fix. Meanwhile components just subscribe to the parts of it they naturally need.
- Note how computed values, such as `isConfigLoaded` is used: `const isConfigLoaded = useStore(state => state.isConfigLoaded());`
- Config is folded naturally into the notion of state, and state logic actions can and do use it.
- This project did not contain egregious prop drilling, but Zustand still results in a noticeable simplification of all the components that use state (directly or via props).
- IMO, components have become slightly to moderately easier to understand, due in part to the segregation of state logic to the store.
