### PR TITLE
Add npm policy, node 24, pin CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "22"
+      "version": "24"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {},
     "ghcr.io/devcontainers/features/python:1": {

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -4,4 +4,7 @@ set -ex
 # Convenience workspace directory for later use
 WORKSPACE_DIR=$(pwd)
 
-npm install
+sudo npm install --global npm@12
+test "$(node --version | cut -d. -f1 | tr -d v)" = "24"
+test "$(npm --version | cut -d. -f1)" = "12"
+npm ci

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,21 +12,40 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Export REACT_APP_APP_VERSION env var
         run: |
           git fetch --prune --unshallow
           echo "REACT_APP_APP_VERSION=$(git describe --tags --abbrev=0) ($(git rev-parse --abbrev-ref HEAD):$(git log -1 --format=%h))" >> $GITHUB_ENV
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+      - name: Standardize npm
+        run: npm install --global npm@12
+      - name: Verify Node/npm toolchain
+        shell: bash
+        run: |
+          echo "Node: $(node --version)"
+          echo "npm:  $(npm --version)"
+          test "$(node --version | cut -d. -f1 | tr -d v)" = "24"
+          test "$(npm --version | cut -d. -f1)" = "12"
       - name: Build npm package
         run: |
           npm ci
           npm run build
-      - name: Publish to Registry
-        uses: docker/build-push-action@v1
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
-          dockerfile: docker/Dockerfile
-          repository: pcic/weather-anomaly-tool
-          tag_with_ref: true
-          build_args: REACT_APP_APP_VERSION=${{ env.REACT_APP_APP_VERSION }}
+
+      - name: Publish to Registry
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          build-args: REACT_APP_APP_VERSION=${{ env.REACT_APP_APP_VERSION }}
+          push: true
+          tags: pcic/weather-anomaly-tool:${{ github.ref_name }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -7,13 +7,24 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          node-version: 22
+          persist-credentials: false
+      - name: Set up Node.js 24
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+      - name: Standardize npm
+        run: npm install --global npm@12
+      - name: Verify Node/npm toolchain
+        shell: bash
+        run: |
+          echo "Node: $(node --version)"
+          echo "npm:  $(npm --version)"
+          test "$(node --version | cut -d. -f1 | tr -d v)" = "24"
+          test "$(npm --version | cut -d. -f1)" = "12"
       - name: Node.js Test Suite
         run: |
-          npm install
+          npm ci
           npm run build
           npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Repository dependency security policy
+min-release-age=7
+strict-allow-scripts=true
+allow-git=root
+allow-remote=none

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,14 @@
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 RUN apt-get -y update &&  \ 
     apt-get install --no-install-recommends  \
     -y curl rpl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g serve
+RUN npm install --global npm@12 && \
+    test "$(node --version | cut -d. -f1 | tr -d v)" = "24" && \
+    test "$(npm --version | cut -d. -f1)" = "12" && \
+    npm install --global serve
 
 COPY --chown=node build /app
 COPY --chown=node docker/entrypoint.sh /app/docker/entrypoint.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
-        "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#node24-npm12-security-policy",
+        "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#3.3.0",
         "proj4": "^2.11.0",
         "proj4leaflet": "^1.0.2",
         "prop-types": "^15.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weather-anomaly-tool",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weather-anomaly-tool",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@tanstack/react-query": "^5.48.0",
@@ -17,7 +17,7 @@
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
-        "pcic-react-leaflet-components": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3.2.0",
+        "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#node24-npm12-security-policy",
         "proj4": "^2.11.0",
         "proj4leaflet": "^1.0.2",
         "prop-types": "^15.8.1",
@@ -38,6 +38,10 @@
         "@craco/craco": "^7.1.0",
         "prettier": "3.3.2",
         "react-app-alias": "^2.2.2"
+      },
+      "engines": {
+        "node": "24.x",
+        "npm": "12.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14690,7 +14694,7 @@
     },
     "node_modules/pcic-react-leaflet-components": {
       "version": "3.2.0",
-      "resolved": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d11604c6c3ff6ec0dbe96523d068639a8cf573e2",
+      "resolved": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#fb822d7c29d9ca463963e9d5e846458e07ef3105",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -14702,6 +14706,10 @@
         "react-scripts": "5.0.1",
         "svg-loaders-react": "^2.2.1",
         "web-vitals": "^2.1.4"
+      },
+      "engines": {
+        "node": "24.x",
+        "npm": "12.x"
       },
       "peerDependencies": {
         "@react-leaflet/core": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "pcic-react-leaflet-components": "git+https://git@github.com/pacificclimate/pcic-react-leaflet-components.git#3.2.0",
+    "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#node24-npm12-security-policy",
     "proj4": "^2.11.0",
     "proj4leaflet": "^1.0.2",
     "prop-types": "^15.8.1",
@@ -43,7 +43,7 @@
     "build": "craco build",
     "test": "craco test --env=jsdom --transformIgnorePatterns \"node_modules/(?!pcic-react-leaflet-components)/\"",
     "eject": "react-scripts eject",
-    "reinstall": "rm -rf ./node_modules; npm install --include=dev",
+    "reinstall": "npm ci",
     "format": "prettier --write .",
     "check-format": "prettier --check ."
   },
@@ -52,5 +52,13 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "engines": {
+    "node": "24.x",
+    "npm": "12.x"
+  },
+  "allowScripts": {
+    "core-js@3.37.1": true,
+    "core-js-pure@3.37.1": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#node24-npm12-security-policy",
+    "pcic-react-leaflet-components": "git+https://github.com/pacificclimate/pcic-react-leaflet-components.git#3.3.0",
     "proj4": "^2.11.0",
     "proj4leaflet": "^1.0.2",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
- Require Node 24 and npm 12.
- Add an .npmrc security policy to reduce npm supply-chain risk
- Bump CI actions, pin commit SHAs

### Before Merge:
return to tagged version of pcic-react-leaflet-components